### PR TITLE
feat: 記事作成ボタンを管理者専用に変更

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -33,7 +33,7 @@
             <NuxtLink v-if="isAdmin" to="/admin" class="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-500 transition duration-200">
               管理画面
             </NuxtLink>
-            <NuxtLink to="/articles/new" class="bg-blue-600 dark:bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-700 dark:hover:bg-blue-600 transition duration-200">
+            <NuxtLink v-if="isAdmin" to="/articles/new" class="bg-blue-600 dark:bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-700 dark:hover:bg-blue-600 transition duration-200">
               記事を投稿
             </NuxtLink>
             <button
@@ -80,7 +80,7 @@
         <div v-if="user">
           <span class="block text-sm text-gray-600 dark:text-gray-400 py-2">{{ user.email }}</span>
           <NuxtLink v-if="isAdmin" to="/admin" class="block text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-500 py-2">管理画面</NuxtLink>
-          <NuxtLink to="/articles/new" class="block bg-blue-600 dark:bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-700 dark:hover:bg-blue-600">記事を投稿</NuxtLink>
+          <NuxtLink v-if="isAdmin" to="/articles/new" class="block bg-blue-600 dark:bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-700 dark:hover:bg-blue-600">記事を投稿</NuxtLink>
           <button
             @click="handleLogout"
             class="block w-full text-left text-gray-700 dark:text-gray-300 hover:text-red-600 dark:hover:text-red-400 py-2"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,10 +11,7 @@
           Web開発、プログラミング、新技術の探求について発信しています。
         </p>
         <div class="space-x-4">
-          <NuxtLink to="/articles/new" class="bg-white text-blue-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition duration-200">
-            記事を投稿する
-          </NuxtLink>
-          <NuxtLink to="/articles" class="border-2 border-white text-white px-8 py-3 rounded-lg font-semibold hover:bg-white hover:text-blue-600 transition duration-200">
+          <NuxtLink to="/articles" class="bg-white text-blue-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition duration-200">
             記事を読む
           </NuxtLink>
         </div>


### PR DESCRIPTION
## Summary
- ホームページのHeroセクションから記事投稿ボタンを削除
- ヘッダーの記事投稿ボタンを管理者のみ表示に制限（デスクトップ・モバイル両方）

## Test plan
- [ ] 一般ユーザーでログインしてホームページと記事投稿ボタンが表示されないことを確認
- [ ] 管理者でログインしてヘッダーに記事投稿ボタンが表示されることを確認
- [ ] モバイル表示でも同様に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)