### PR TITLE
fix: 記事投稿ページのミドルウェアを管理者専用に修正

### DIFF
--- a/pages/articles/new.vue
+++ b/pages/articles/new.vue
@@ -100,7 +100,7 @@
 
 <script setup>
 definePageMeta({
-  middleware: 'auth'
+  middleware: 'admin'
 })
 
 const router = useRouter()


### PR DESCRIPTION
## Summary
• 記事投稿ページ(`/articles/new.vue`)のミドルウェアを`auth`から`admin`に変更
• 管理者権限を持つユーザーのみが記事投稿ページにアクセス可能に修正

## Test plan
- [ ] 管理者ユーザーでログインして記事投稿ページにアクセスできることを確認
- [ ] 一般ユーザーで記事投稿ページにアクセスしようとすると権限エラーが表示されることを確認
- [ ] 管理者ユーザーで記事の投稿が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)