### PR TITLE
fix: リロード時にログアウト状態になる問題を修正

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -7,9 +7,16 @@
 <script setup>
 // サンプルデータの初期化
 const { initSampleArticles } = useInitSampleData()
+const { refreshUser, initAuthListener } = useAuth()
 
-onMounted(() => {
+onMounted(async () => {
   // アプリケーション起動時にサンプルデータを初期化
   initSampleArticles()
+  
+  // 認証状態を復元
+  await refreshUser()
+  
+  // 認証状態変更のリスナーを初期化
+  initAuthListener()
 })
 </script>

--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -83,6 +83,19 @@ export const useAuth = () => {
     }
   }
 
+  const initAuthListener = () => {
+    if (!$supabase) return
+
+    $supabase.auth.onAuthStateChange(async (event, session) => {
+      if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+        await refreshUser()
+      } else if (event === 'SIGNED_OUT') {
+        user.value = null
+        isAdmin.value = false
+      }
+    })
+  }
+
   const isAuthenticated = computed(() => !!user.value)
   const canPostArticle = computed(() => isAuthenticated.value)
 
@@ -94,6 +107,7 @@ export const useAuth = () => {
     signUp,
     signIn,
     signOut,
-    refreshUser
+    refreshUser,
+    initAuthListener
   }
 }


### PR DESCRIPTION
## Summary
• アプリケーション起動時に認証状態を復元する処理を追加
• Supabaseの認証状態変更を監視するリスナーを実装
• リロード時に認証状態が保持されるよう修正

## Changes
• `app.vue`: アプリ起動時に`refreshUser()`と`initAuthListener()`を呼び出し
• `composables/useAuth.ts`: `onAuthStateChange`リスナーを追加して認証状態を監視

## Test plan
- [ ] ログイン後にページをリロードしても認証状態が保持されることを確認
- [ ] 管理者でログイン後にリロードしても管理者権限が保持されることを確認
- [ ] ログアウト操作が正常に動作することを確認
- [ ] 新規ログイン時に認証状態が正しく設定されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)