### PR TITLE
remove: ヘッダーから記事投稿ボタンを削除

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -33,9 +33,6 @@
             <NuxtLink v-if="isAdmin" to="/admin" class="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-500 transition duration-200">
               管理画面
             </NuxtLink>
-            <NuxtLink v-if="isAdmin" to="/articles/new" class="bg-blue-600 dark:bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-700 dark:hover:bg-blue-600 transition duration-200">
-              記事を投稿
-            </NuxtLink>
             <button
               @click="handleLogout"
               class="text-gray-700 dark:text-gray-300 hover:text-red-600 dark:hover:text-red-400 transition duration-200"
@@ -80,7 +77,6 @@
         <div v-if="user">
           <span class="block text-sm text-gray-600 dark:text-gray-400 py-2">{{ user.email }}</span>
           <NuxtLink v-if="isAdmin" to="/admin" class="block text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-500 py-2">管理画面</NuxtLink>
-          <NuxtLink v-if="isAdmin" to="/articles/new" class="block bg-blue-600 dark:bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-700 dark:hover:bg-blue-600">記事を投稿</NuxtLink>
           <button
             @click="handleLogout"
             class="block w-full text-left text-gray-700 dark:text-gray-300 hover:text-red-600 dark:hover:text-red-400 py-2"


### PR DESCRIPTION
## Summary
• ヘッダーから記事投稿ボタンを削除
• 記事投稿は管理画面からのみアクセス可能に変更

## Changes
• `components/Header.vue`: デスクトップとモバイル両方の記事投稿ボタンを削除

## Test plan
- [ ] 管理者でログインしてもヘッダーに記事投稿ボタンが表示されないことを確認
- [ ] 管理画面からは記事投稿ページにアクセスできることを確認
- [ ] ヘッダーの他の機能（管理画面、ログアウト）が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)